### PR TITLE
Strip leading slash in IndexYamlAbsoluteUrlRewriter

### DIFF
--- a/src/main/java/org/sonatype/repository/helm/internal/metadata/IndexYamlAbsoluteUrlRewriter.java
+++ b/src/main/java/org/sonatype/repository/helm/internal/metadata/IndexYamlAbsoluteUrlRewriter.java
@@ -108,6 +108,10 @@ public class IndexYamlAbsoluteUrlRewriter
       URI uri = new URIBuilder(oldUrl).build();
       if (uri.isAbsolute()) {
         String fileName = uri.getPath();
+        // Strip leading slash
+        if (!fileName.isEmpty()) {
+            fileName = fileName.substring(1);
+        }
         scalarEvent = new ScalarEvent(scalarEvent.getAnchor(), scalarEvent.getTag(),
             scalarEvent.getImplicit(), fileName, scalarEvent.getStartMark(),
             scalarEvent.getEndMark(), scalarEvent.getStyle());

--- a/src/test/java/org/sonatype/repository/helm/internal/metadata/IndexYamlAbsoluteUrlRewriterTest.java
+++ b/src/test/java/org/sonatype/repository/helm/internal/metadata/IndexYamlAbsoluteUrlRewriterTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -86,11 +87,17 @@ public class IndexYamlAbsoluteUrlRewriterTest
 
   private void checkThatAbsoluteUrlRemoved(final InputStream is) throws Exception {
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+      boolean checkNext = false;
       String line;
       while ((line = reader.readLine()) != null) {
         line = line.trim();
-        if (line.contains(INDEX_YAML_URL_NODE)) {
+        if (checkNext) {
           assertThat(line, either(not(containsString(HTTP))).or(not(containsString(HTTPS))));
+          assertThat(line, not(startsWith("- /")));
+          checkNext = false;
+        }
+        if (line.contains(INDEX_YAML_URL_NODE)) {
+          checkNext = true;
         }
       }
     }


### PR DESCRIPTION
This pull request makes the following changes:
* Strips leading slash from IndexYamlAbsoluteUrlRewriter

The URIBuilder `getPath` method returns a leading slash in the path, which shouldn't be included in the generated Index YAML.
