### PR TITLE
Allow missing optional Chart.yaml attributes

### DIFF
--- a/src/main/java/org/sonatype/repository/helm/internal/util/HelmAttributeParser.java
+++ b/src/main/java/org/sonatype/repository/helm/internal/util/HelmAttributeParser.java
@@ -57,11 +57,18 @@ public class HelmAttributeParser
       HelmAttributes helmAttributes = new HelmAttributes();
       helmAttributes.setName(attributes.get(NAME).toString());
       helmAttributes.setVersion(attributes.get(VERSION).toString());
-      helmAttributes.setDescription(attributes.get(DESCRIPTION).toString());
-      helmAttributes.setIcon(attributes.get(ICON).toString());
-      helmAttributes.setMaintainers((List<Map<String, String>>)attributes.get(MAINTAINERS));
-      helmAttributes.setSources((List<String>)attributes.get(SOURCES));
-
+      if (attributes.get(DESCRIPTION) != null) {
+        helmAttributes.setDescription(attributes.get(DESCRIPTION).toString());
+      }
+      if (attributes.get(ICON) != null) {
+        helmAttributes.setIcon(attributes.get(ICON).toString());
+      }
+      if (attributes.get(MAINTAINERS) != null) {
+        helmAttributes.setMaintainers((List<Map<String, String>>)attributes.get(MAINTAINERS));
+      }
+      if (attributes.get(SOURCES) != null) {
+        helmAttributes.setSources((List<String>)attributes.get(SOURCES));
+      }
       return helmAttributes;
     }
   }


### PR DESCRIPTION
This pull request makes the following changes:
* Allows missing optional Chart.yaml attributes

See https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file for specification as to what fields are optional.