### PR TITLE
fix issue that appVersion field isn't set in index.yaml

### DIFF
--- a/src/main/java/org/sonatype/repository/helm/internal/database/HelmProperties.java
+++ b/src/main/java/org/sonatype/repository/helm/internal/database/HelmProperties.java
@@ -31,7 +31,7 @@ public interface HelmProperties
 
   String MAINTAINERS = "maintainers";
 
-  String APP_VERSION = "app_version";
+  String APP_VERSION = "appVersion";
 
   String ATTRIBUTES_HELM_ASSET_KIND = "attributes.helm.asset_kind";
 }


### PR DESCRIPTION
This pull request makes the following changes:
changes the property APP_VERSION value.
"app_version" field isn't supported by Helm. 
Changed it to "appVersion"
