### PR TITLE
Fix jline lib issue during bundle:start.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: java
+
+jdk:
+  - oraclejdk8
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/src/main/java/org/sonatype/repository/helm/internal/hosted/HostedHandlers.java
+++ b/src/main/java/org/sonatype/repository/helm/internal/hosted/HostedHandlers.java
@@ -24,7 +24,7 @@ import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher.State;
 import org.sonatype.repository.helm.internal.AssetKind;
 import org.sonatype.repository.helm.internal.util.HelmPathUtils;
 
-import static jline.internal.Preconditions.checkNotNull;
+import java.util.Objects;
 import static org.sonatype.nexus.repository.http.HttpResponses.notFound;
 import static org.sonatype.nexus.repository.http.HttpResponses.ok;
 
@@ -42,7 +42,7 @@ public class HostedHandlers
 
   @Inject
   public HostedHandlers(final HelmPathUtils helmPathUtils) {
-    this.helmPathUtils = checkNotNull(helmPathUtils);
+    this.helmPathUtils = Objects.requireNonNull(helmPathUtils);
   }
 
   final Handler get = context -> {


### PR DESCRIPTION
Fixing an error during plugin [temporary install](https://github.com/sonatype-nexus-community/nexus-repository-helm#temporary-install).
```
Error executing command: Error executing command on bundles:
        Error starting bundle 251: Unable to resolve org.sonatype.nexus.plugins.nexus-repository-helm [251](R 251.0): missing requirement [org.sonatype.nexus.plugins.nexus-repository-helm [251](R 251.0)] osgi.wiring.package; (&(osgi.wiring.package=jline.internal)(version>=2.14.0)) Unresolved requirements: [[org.sonatype.nexus.plugins.nexus-repository-helm [251](R 251.0)] osgi.wiring.package; (&(osgi.wiring.package=jline.internal)(version>=2.14.0))]
```

This pull request makes the following changes:
* replacing `jline.internal.Preconditions.checkNotNull` with `java.util.Objects.requireNonNull`
