### PR TITLE
Pom cleanups

### DIFF
--- a/nexus-repository-helm-it/pom.xml
+++ b/nexus-repository-helm-it/pom.xml
@@ -25,7 +25,6 @@
   </parent>
 
   <artifactId>nexus-repository-helm-it</artifactId>
-  <packaging>bundle</packaging>
 
   <dependencies>
     <!--
@@ -177,5 +176,4 @@
 
     </plugins>
   </build>
-
 </project>

--- a/nexus-repository-helm/pom.xml
+++ b/nexus-repository-helm/pom.xml
@@ -16,16 +16,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>nexus-repository-base</artifactId>
     <groupId>org.sonatype.nexus.plugins</groupId>
+    <artifactId>nexus-repository-base</artifactId>
     <version>0.0.13</version>
   </parent>
 
   <artifactId>nexus-repository-helm</artifactId>
-  <name>${project.groupId}:${project.artifactId}</name>
-  <inceptionYear>2018</inceptionYear>
   <packaging>bundle</packaging>
+
+  <inceptionYear>2018</inceptionYear>
 
   <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,10 @@
   </parent>
 
   <artifactId>nexus-repository-base</artifactId>
-  <groupId>org.sonatype.nexus.plugins</groupId>
-  <name>${project.groupId}:${project.artifactId}</name>
   <version>0.0.13</version>
-  <inceptionYear>2018</inceptionYear>
   <packaging>pom</packaging>
+
+  <inceptionYear>2018</inceptionYear>
 
   <modules>
     <module>nexus-repository-helm</module>
@@ -55,15 +54,27 @@
 
   <build>
     <plugins>
+      <!--
+      Ensure use of Java 8, as required by NXRM
+      -->
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>rso</serverId>
-          <nexusUrl>https://repository.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8,1.9)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -101,6 +112,16 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>rso</serverId>
+              <nexusUrl>https://repository.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Some pom.xml cleanups and features (some of which are already incorporated into the [nexus-format-archetype](https://github.com/sonatype-nexus-community/nexus-format-archetype)).

This pull request makes the following changes:
* [mvn:tidy](https://www.mojohaus.org/tidy-maven-plugin/) - a nice standard pom layout tool (ignored the 'xmlns' changes to keep it simple for now)
* Ensure use of Java 8, as required by NXRM
* move nexus-staging-maven-plugin to 'deploy' profile 
* remove 'bundle' packaging from IT module.
* remove unneeded tags

