### PR TITLE
use simplified Dockerfile, taken from nexus format plugin archetype project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,18 @@
-ARG NEXUS_VERSION=3.18.0
+# declaration of NEXUS_VERSION must appear before first FROM command
+# see: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG NEXUS_VERSION=latest
 
 FROM maven:3-jdk-8-alpine AS build
-ARG NEXUS_VERSION=3.18.0
-ARG NEXUS_BUILD=01
 
 COPY . /nexus-repository-helm/
-RUN cd /nexus-repository-helm/; sed -i "s/3.18.0-01/${NEXUS_VERSION}-${NEXUS_BUILD}/g" pom.xml; \
-    mvn clean package;
+RUN cd /nexus-repository-helm/; \
+    mvn clean package -PbuildKar;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
-ARG NEXUS_VERSION=3.18.0
-ARG NEXUS_BUILD=01
-ARG HELM_VERSION=0.0.12
-ARG COMP_VERSION=1.18
-ARG TARGET_DIR=/opt/sonatype/nexus/system/org/sonatype/nexus/plugins/nexus-repository-helm/${HELM_VERSION}/
+
+ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
-RUN mkdir -p ${TARGET_DIR}; \
-    sed -i 's@nexus-repository-maven</feature>@nexus-repository-maven</feature>\n        <feature prerequisite="false" dependency="false">nexus-repository-helm</feature>@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml; \
-    sed -i 's@<feature name="nexus-repository-maven"@<feature name="nexus-repository-helm" description="org.sonatype.nexus.plugins:nexus-repository-helm" version="'"${HELM_VERSION}"'">\n        <details>org.sonatype.nexus.plugins:nexus-repository-helm</details>\n        <bundle>mvn:org.sonatype.nexus.plugins/nexus-repository-helm/'"${HELM_VERSION}"'</bundle>\n        <bundle>mvn:org.apache.commons/commons-compress/'"${COMP_VERSION}"'</bundle>\n   </feature>\n    <feature name="nexus-repository-maven"@g' /opt/sonatype/nexus/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}-${NEXUS_BUILD}/nexus-core-feature-${NEXUS_VERSION}-${NEXUS_BUILD}-features.xml;
-COPY --from=build /nexus-repository-helm/target/nexus-repository-helm-${HELM_VERSION}.jar ${TARGET_DIR}
+# @todo Change the COPY source directory after IT modules are introduced from 'development' branch
+#COPY --from=build /nexus-repository-helm/nexus-repository-helm/target/nexus-repository-helm-*-bundle.kar ${DEPLOY_DIR}
+COPY --from=build /nexus-repository-helm/target/nexus-repository-helm-*-bundle.kar ${DEPLOY_DIR}
 USER nexus

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ In the examples below, substitute `0.0.12` with the current version of the helm 
 
 #### Build with Docker
 
-`docker build -t nexus-repository-helm:0.0.12 .`
+    docker build -t nexus-repository-helm .
 
 #### Run as a Docker container
 
-`docker run -d -p 8081:8081 --name nexus nexus-repository-helm:0.0.12` 
+    docker run -d -p 8081:8081 --name nexus-repository-helm nexus-repository-helm
 
 For further information like how to persist volumes check out [the GitHub repo for our official image](https://github.com/sonatype/docker-nexus3).
 
@@ -71,10 +71,10 @@ The application will now be available from your browser at http://localhost:8081
   (/nexus-data/admin.password) in order to login to Nexus. The command below will open a bash shell 
   in the container named `nexus`:
 
-      docker exec -it nexus /bin/bash
+      docker exec -it nexus-repository-helm /bin/bash
       $ cat /nexus-data/admin.password 
       
-  Once logged into the application UI as `admin` using the generated password, you may also want to 
+  Once logged into the application UI as `admin` using the generated password, you should also 
   turn on "Enable anonymous access" when prompted by the setup wizard.     
 
 ## Using Helm With Nexus Repository Manager 3


### PR DESCRIPTION
The current Dockerfile has a number of references to version numbers, that easily get out of date and require maintenance going forward. (Thanks to @davidkarlsen for being so diligent in keeping these versions updated! see PR #67, #68, #71, and Apologies for being so slow to review those PRs).

This new Dockerfile removes the hard coded version numbers, and uses `.kar` file deployment method.
\<shamelessProjectPlug>
This [Docker file](https://github.com/sonatype-nexus-community/nexus-format-archetype/blob/master/src/main/resources/archetype-resources/Dockerfile) is taken from our nifty maven archetype: [nexus-format-archetype](https://github.com/sonatype-nexus-community/nexus-format-archetype). You can use this archetype to easily create a new format plugin for Nexus Repository Manager.
\</shamelessProjectPlug > :)

It relates to the following issue #s:
* Fixes #67
* Fixes #68
* Fixes #71
