### PR TITLE
Added MAVEN_OPTS arg to the build container. This allows to pass opti…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 ARG NEXUS_VERSION=latest
 
 FROM maven:3-jdk-8-alpine AS build
+ARG MAVEN_OPTS
 
 COPY . /nexus-repository-helm/
 RUN cd /nexus-repository-helm/; \


### PR DESCRIPTION
Added MAVEN_OPTS arg to the build container. This allows to pass options to maven, useful for proxies etc.

`docker build --build-arg MAVEN_OPTS="-Dhttp.proxyHost=proxy -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=3128" .`

This pull request makes the following changes:
* Adds MAVEN_OPTS argument to the build container