### PR TITLE
Fixed version string of repo index

### DIFF
--- a/nexus-repository-helm/src/main/java/org/sonatype/repository/helm/internal/createindex/CreateIndexServiceImpl.java
+++ b/nexus-repository-helm/src/main/java/org/sonatype/repository/helm/internal/createindex/CreateIndexServiceImpl.java
@@ -62,7 +62,7 @@ public class CreateIndexServiceImpl
     extends ComponentSupport
     implements CreateIndexService
 {
-  private final static String API_VERSION = "1.0";
+  private final static String API_VERSION = "v1";
 
   private IndexYamlBuilder indexYamlBuilder;
 


### PR DESCRIPTION
(brief, plain english overview of your changes here)

This pull request makes the following changes:
* Changes the `apiVersion` from `'1.0'` to `'v1'` in the generated repository index, so it's a valid API version, conforming to the helm format. See any `index.yaml` generated by `helm serve` or inspect the [official helm `index.yaml` file](https://kubernetes-charts.storage.googleapis.com/index.yaml) (warning: 7+mb), or the [official examples](https://v3.helm.sh/docs/topics/chart_repository/)

Some tools attempt to verify if they are compatible with the version being served and fail on a nexus hosted helm repository.