### PR TITLE
nexus-cleanup scope should be 'provided' …

### DIFF
--- a/nexus-repository-helm/pom.xml
+++ b/nexus-repository-helm/pom.xml
@@ -74,6 +74,7 @@
     <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-cleanup</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
… to avoid leaking NXRM dependencies into the plugin's feature.xml