### PR TITLE
NEXUS-23973 - Fix authentication in HelmResourceIT

### DIFF
--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/rest/ResourceITSupport.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/rest/ResourceITSupport.java
@@ -104,11 +104,9 @@ public class ResourceITSupport
     CleanupPolicyAttributes cleanup = new CleanupPolicyAttributes(Collections.emptyList());
     ProxyAttributes proxy = new ProxyAttributes("http://example.net", 1, 2);
     NegativeCacheAttributes negativeCache = new NegativeCacheAttributes(false, 1440);
-    HttpClientConnectionAuthenticationAttributes authentication =
-        new HttpClientConnectionAuthenticationAttributes("username", null, null, null, null);
     HttpClientConnectionAttributes connection =
         new HttpClientConnectionAttributes(1, null, 5, false, false);
-    HttpClientAttributes httpClient = new HttpClientAttributes(false, true, connection, authentication);
+    HttpClientAttributes httpClient = new HttpClientAttributes(false, true, connection, null);
 
     // SET YOUR FORMAT DATA
     return new HelmProxyRepositoryApiRequest(PROXY_NAME, true, storage, cleanup,


### PR DESCRIPTION
HelmResourceIT creates an empty authentication object. This doesn't cause a test failure because saving the authentication info is broken in all REST APIs for the current Nexus Repository Manager release.

The next release of Nexus Repository Manager fixes this bug which will then cause this test to fail.

This pull request makes the following changes:
* removes creation of empty authentication object
