### PR TITLE
NEXUS-22489 fixed IT updates

### DIFF
--- a/nexus-repository-helm-it/pom.xml
+++ b/nexus-repository-helm-it/pom.xml
@@ -86,6 +86,17 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older r plugins from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-repository-helm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-restore-helm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/nexus-repository-helm-it/pom.xml
+++ b/nexus-repository-helm-it/pom.xml
@@ -87,7 +87,7 @@
       <type>zip</type>
       <scope>test</scope>
       <exclusions>
-        <!-- Avoid leaking older r plugins from distro -->
+        <!-- Avoid leaking older helm plugins from distro -->
         <exclusion>
           <groupId>org.sonatype.nexus.plugins</groupId>
           <artifactId>nexus-repository-helm</artifactId>

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/HelmITConfig.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/HelmITConfig.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.plugins.helm;
 
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/HelmITConfig.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/HelmITConfig.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.plugins.helm;
+
+import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
+import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
+
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.sonatype.nexus.pax.exam.NexusPaxExamSupport.nexusFeature;
+
+public class HelmITConfig
+{
+  public static Option[] configureHelmBase() {
+    return NexusPaxExamSupport.options(
+        NexusITSupport.configureNexusBase(),
+        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm"),
+        systemProperty("nexus-exclude-features").value("nexus-cma-community")
+    );
+  }
+}

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/HelmHostedIT.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/HelmHostedIT.java
@@ -42,6 +42,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.sonatype.nexus.plugins.helm.HelmITConfig.configureHelmBase;
 import static org.sonatype.nexus.repository.http.HttpStatus.NOT_FOUND;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
@@ -54,10 +55,7 @@ public class HelmHostedIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm")
-    );
+    return configureHelmBase();
   }
 
   @Before

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/HelmProxyIT.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/HelmProxyIT.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.error;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.file;
+import static org.sonatype.nexus.plugins.helm.HelmITConfig.configureHelmBase;
 
 public class HelmProxyIT
     extends HelmITSupport
@@ -42,10 +43,7 @@ public class HelmProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return options(
-        configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm")
-    );
+    return configureHelmBase();
   }
 
   @Before

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/cleanup/CleanupTaskHelmIT.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/cleanup/CleanupTaskHelmIT.java
@@ -35,6 +35,7 @@ import org.ops4j.pax.exam.Option;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.sonatype.nexus.plugins.helm.HelmITConfig.configureHelmBase;
 import static org.sonatype.nexus.plugins.helm.internal.HelmITSupport.MONGO_PKG_FILE_NAME_404_TGZ;
 import static org.sonatype.nexus.plugins.helm.internal.HelmITSupport.MONGO_PKG_FILE_NAME_600_TGZ;
 import static org.sonatype.nexus.plugins.helm.internal.HelmITSupport.MONGO_PKG_FILE_NAME_728_TGZ;
@@ -55,10 +56,7 @@ public class CleanupTaskHelmIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm")
-    );
+    return configureHelmBase();
   }
 
   @Before

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/restore/HelmRestoreBlobIT.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/internal/restore/HelmRestoreBlobIT.java
@@ -47,6 +47,7 @@ import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.file;
 import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.HEADER_PREFIX;
 import static org.sonatype.nexus.blobstore.api.BlobStore.BLOB_NAME_HEADER;
 import static org.sonatype.nexus.blobstore.api.BlobStore.CONTENT_TYPE_HEADER;
+import static org.sonatype.nexus.plugins.helm.HelmITConfig.configureHelmBase;
 import static org.sonatype.nexus.repository.storage.Bucket.REPO_NAME_HEADER;
 
 public class HelmRestoreBlobIT
@@ -76,8 +77,7 @@ public class HelmRestoreBlobIT
   @Configuration
   public static Option[] configureNexus() {
     return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm"),
+        configureHelmBase(),
         nexusFeature("org.sonatype.nexus.plugins", "nexus-restore-helm")
     );
   }

--- a/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/rest/HelmResourceIT.java
+++ b/nexus-repository-helm-it/src/test/java/org/sonatype/nexus/plugins/helm/rest/HelmResourceIT.java
@@ -19,16 +19,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.sonatype.nexus.plugins.helm.HelmITConfig.configureHelmBase;
 
 public class HelmResourceIT
     extends ResourceITSupport
 {
   @Configuration
   public static Option[] configureNexus() {
-    return options(
-        configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-helm")
-    );
+    return configureHelmBase();
   }
 
   @Before

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.23.0-01</version>
+    <version>3.25.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-repository-base</artifactId>
@@ -48,7 +48,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.23.0-01</nxrm-version>
+    <nxrm-version>3.25.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
ITs now use the actual repository code instead of the version of the plugin from the parent (NXRM)

The issue explains the problem for R format https://issues.sonatype.org/browse/NEXUS-22489

