### PR TITLE
Adding extra setup for mocks in IndexYamlBuilderTest

### DIFF
--- a/nexus-repository-helm/src/test/java/org/sonatype/repository/helm/internal/orient/metadata/IndexYamlBuilderTest.java
+++ b/nexus-repository-helm/src/test/java/org/sonatype/repository/helm/internal/orient/metadata/IndexYamlBuilderTest.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.repository.helm.internal.orient.metadata;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -21,6 +22,7 @@ import org.sonatype.nexus.repository.storage.TempBlob;
 import org.sonatype.repository.helm.internal.metadata.ChartIndex;
 import org.sonatype.repository.helm.internal.util.YamlParser;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -51,6 +53,7 @@ public class IndexYamlBuilderTest
 
   @Before
   public void setUp() throws Exception {
+    setupRepositoryMock();
     underTest = new IndexYamlBuilder(this.yamlParser);
     index = new ChartIndex();
   }
@@ -78,5 +81,14 @@ public class IndexYamlBuilderTest
 
   private void initializeStorageFacet() {
     when(storageFacet.createTempBlob(any(InputStream.class), eq(HASH_ALGORITHMS))).thenReturn(tempBlob);
+  }
+
+  private void setupRepositoryMock() {
+    when(storageFacet.createTempBlob(any(InputStream.class), any(Iterable.class))).thenAnswer(args -> {
+      InputStream inputStream = (InputStream) args.getArguments()[0];
+      byte[] bytes = IOUtils.toByteArray(inputStream);
+      when(tempBlob.get()).thenReturn(new ByteArrayInputStream(bytes));
+      return tempBlob;
+    });
   }
 }

--- a/nexus-repository-helm/src/test/java/org/sonatype/repository/helm/internal/orient/metadata/IndexYamlBuilderTest.java
+++ b/nexus-repository-helm/src/test/java/org/sonatype/repository/helm/internal/orient/metadata/IndexYamlBuilderTest.java
@@ -53,13 +53,13 @@ public class IndexYamlBuilderTest
 
   @Before
   public void setUp() throws Exception {
-    setupRepositoryMock();
     underTest = new IndexYamlBuilder(this.yamlParser);
     index = new ChartIndex();
   }
 
   @Test
   public void testChartIndexPassedCorrectly() throws Exception {
+    setupRepositoryMock();
     ArgumentCaptor<InputStream> captorStorage = ArgumentCaptor.forClass(InputStream.class);
     ArgumentCaptor<ChartIndex> captor = ArgumentCaptor.forClass(ChartIndex.class);
 


### PR DESCRIPTION
This pull request makes the following changes:
* Add extra setup code for the mock, as that seems to be what leads to the error. The added method, `setupRepositoryMock`, is partially taken from `IndexYamlAbsoluteUrlRewriterTest`, and calling this setup before the tests run makes it such that `testChartIndexPassedCorrectly` can pass when run after those other two tests.

It relates to the following issue #s:
Fixes #138 