### PR TITLE
NEXUS-24569: helm component name does not contain version anymore

### DIFF
--- a/nexus-repository-helm/src/main/java/org/sonatype/repository/helm/internal/content/recipe/HelmContentFacetImpl.java
+++ b/nexus-repository-helm/src/main/java/org/sonatype/repository/helm/internal/content/recipe/HelmContentFacetImpl.java
@@ -139,7 +139,7 @@ public class HelmContentFacetImpl
         .path(path)
         .kind(assetKind.name())
         .component(components()
-            .name(path)
+            .name(helmAttributes.getName())
             .version(helmAttributes.getVersion())
             .getOrCreate())
         .getOrCreate()


### PR DESCRIPTION
Tickect: https://issues.sonatype.org/browse/NEXUS-24569